### PR TITLE
handle taglink conflict

### DIFF
--- a/src/api/CustomerRemoteService.js
+++ b/src/api/CustomerRemoteService.js
@@ -82,6 +82,23 @@ export class CustomerRemoteService extends RemoteService {
         return await this._handleResponse(response);
     }
 
+    async getRemoteRecordByUniqueKeys(collection, keys) {
+        const query = new URLSearchParams();
+        const searchParts = Object.entries(keys).map(([k, v]) => {
+            if (typeof v === 'string') {
+                return `${k} = "${v}"`;
+            }
+            return `${k} = ${v}`;
+        });
+        query.set('filter', searchParts.join(' && '));
+        const response = await fetch(`${this.url}/${collection}?${query.toString()}`, {
+            method: 'GET',
+            headers: buildHeaders(this.token)
+        });
+        const list = await this._handleResponse(response);
+        return list && list.length > 0 ? list[0] : null;
+    }
+
     async create(collection, data) {
         const response = await fetch(`${this.url}/${collection}`, {
             method: 'POST',

--- a/src/api/PocketBaseService.js
+++ b/src/api/PocketBaseService.js
@@ -78,6 +78,17 @@ export class PocketBaseService extends RemoteService {
         return await this.client.collection(collection).getFirstListItem(searchString);
     }
 
+    async getRemoteRecordByUniqueKeys(collection, keys) {
+        const searchParts = Object.entries(keys).map(([k, v]) => {
+            if (typeof v === 'string') {
+                return `${k} = "${v}"`;
+            }
+            return `${k} = ${v}`;
+        });
+        const searchString = searchParts.join(' && ');
+        return await this.client.collection(collection).getFirstListItem(searchString);
+    }
+
     async create(collection, data) {
         return await this.client.collection(collection).create(data);
     }

--- a/src/api/RemoteService.js
+++ b/src/api/RemoteService.js
@@ -37,6 +37,10 @@ export class RemoteService {
         throw new Error('RemoteService.getByRowId() must be implemented by subclass');
     }
 
+    async getRemoteRecordByUniqueKeys(collection, keys) {
+        throw new Error('RemoteService.getRemoteRecordByUniqueKeys() must be implemented by subclass');
+    }
+
     async create(collection, data) {
         throw new Error('RemoteService.create() must be implemented by subclass');
     }

--- a/src/database/DatabaseService.js
+++ b/src/database/DatabaseService.js
@@ -218,6 +218,39 @@ export class DatabaseService {
         })();
     }
 
+    resolveTagLinkConflict(oldRowid, remoteRecord) {
+        this.createTransaction(() => {
+            // 1. Delete the old record
+            this.db.prepare(`DELETE FROM TAGLINK_V1 WHERE ROWID = ?`).run(oldRowid);
+
+            // 2. Insert the new record with remote TAGLINKID and pb_id
+            const table = 'TAGLINK_V1';
+            const keys = this.schemas[table].fields;
+            const pk = this.schemas[table].pk;
+            const columns = [pk, ...keys, 'pb_id', 'pb_is_dirty', 'pb_updated_at'].join(', ');
+            const placeholders = ['?', ...keys.map(() => '?'), '?', '2', '?'].join(', ');
+            
+            const updatedAt = remoteRecord._updated_at || remoteRecord.updated || new Date().toISOString();
+            
+            const values = [
+                remoteRecord.TAGLINKID,
+                ...keys.map(k => remoteRecord[k]),
+                remoteRecord.id,
+                updatedAt
+            ];
+
+            const result = this.db.prepare(`
+                INSERT INTO TAGLINK_V1 (${columns}) 
+                VALUES (${placeholders})
+            `).run(...values);
+
+            const newRowId = result.lastInsertRowid;
+            
+            // 3. Mark as synchronized (pb_is_dirty = 0)
+            this.db.prepare(`UPDATE TAGLINK_V1 SET pb_is_dirty = 0 WHERE ROWID = ?`).run(newRowId);
+        })();
+    }
+
     getDeletedLog() {
         return this.db.prepare(`SELECT * FROM DELETED_LOG`).all();
     }

--- a/src/services/SyncService.js
+++ b/src/services/SyncService.js
@@ -66,25 +66,52 @@ export class SyncService {
                 }
 
             } catch (err) {
-                if (err && err.response && err.response.data && err.response.data._userid && err.response.data._userid.code == 'validation_not_unique') {
-                    // serach for pk
-                    let remoteRecord;
-                    try {
-                        remoteRecord = await this.pb.getByRowId(table, record.rowid);
-                    } catch (err) {
-                        console.error(`❌ Critical push error on ${table} (rowid: ${record.rowid}) not found and probabily unique constraint violation`, err.message);
-                    }
-                    if (remoteRecord) {
-                        response = await this.pb.update(table, remoteRecord.id, dataToSync);
-                        if (response.id != null) {
-                            if (this.options.verbose) console.log(`[Push] Updated ${table} (rowid: ${record.rowid}) with pb_id: ${response.id}`);
-                            this.db.setSyncedStatus(table, record.rowid, response.id);
+                let isUniqueValidationError = false;
+                if (err && err.response && err.response.data) {
+                    isUniqueValidationError = Object.values(err.response.data).some(
+                        fieldError => fieldError && fieldError.code === 'validation_not_unique'
+                    );
+                }
+
+                if (isUniqueValidationError) {
+                    if (table === 'TAGLINK_V1') {
+                        const { REFTYPE, REFID, TAGID } = record;
+                        let remoteRecord;
+                        try {
+                            remoteRecord = await this.pb.getRemoteRecordByUniqueKeys(table, { REFTYPE, REFID, TAGID });
+                        } catch (queryErr) {
+                            if (queryErr.status !== 404) {
+                                console.error(`❌ Critical push error on ${table} (rowid: ${record.rowid}) taglink query failed:`, queryErr.message);
+                            }
+                        }
+                        if (remoteRecord) {
+                            this.db.resolveTagLinkConflict(record.rowid, remoteRecord);
+                            if (this.options.verbose) {
+                                console.log(`[Push] Resolved conflict for ${table} (rowid: ${record.rowid}) using remote TAGLINKID: ${remoteRecord.TAGLINKID}`);
+                            }
                         } else {
-                            console.log(`❌ Critical push error on ${table} (rowid: ${record.rowid}): ID not returned.`);
+                            console.error(`❌ Critical push error on ${table} (rowid: ${record.rowid}) taglink not found on remote server.`);
+                        }
+                    } else {
+                        // search for pk
+                        let remoteRecord;
+                        try {
+                            remoteRecord = await this.pb.getByRowId(table, record.rowid);
+                        } catch (err) {
+                            console.error(`❌ Critical push error on ${table} (rowid: ${record.rowid}) not found and probabily unique constraint violation`, err.message);
+                        }
+                        if (remoteRecord) {
+                            response = await this.pb.update(table, remoteRecord.id, dataToSync);
+                            if (response.id != null) {
+                                if (this.options.verbose) console.log(`[Push] Updated ${table} (rowid: ${record.rowid}) with pb_id: ${response.id}`);
+                                this.db.setSyncedStatus(table, record.rowid, response.id);
+                            } else {
+                                console.log(`❌ Critical push error on ${table} (rowid: ${record.rowid}): ID not returned.`);
+                            }
                         }
                     }
                 } else {
-                    console.error(`❌ Critical push error on ${table} (rowid: ${record.rowid}):`, err.message);
+                    console.error(`❌ Critical push error on ${table} (rowid: ${record.rowid}):`, err ? err.message : 'Unknown error');
                 }
             }
         }
@@ -110,9 +137,6 @@ export class SyncService {
 
             for (const remote of remoteRecords) {
                 progress.update(`[Pull] ${table}`);
-                if (remote.id === 'djpneq67vq27jqe') {
-                    console.log(`[Pull] Found record in ${table} (pb_id: ${remote.id})`);
-                }
                 try {
                     this.db.applyRemoteChanges(table, remote);
                 } catch (err) {

--- a/tests/api/PocketBaseService.test.js
+++ b/tests/api/PocketBaseService.test.js
@@ -160,6 +160,15 @@ describe('PocketBaseService', () => {
             await service.delete('ACCOUNTLIST_V1', 'id123');
             expect(mockDelete).toHaveBeenCalledWith('id123');
         });
+
+        test('getRemoteRecordByUniqueKeys correctly builds search string and calls pocketbase client', async () => {
+            mockGetFirstListItem.mockResolvedValueOnce(PB_MOCK_SUCCESS_RECORD);
+
+            const result = await service.getRemoteRecordByUniqueKeys('ACCOUNTLIST_V1', { REFTYPE: 'Transaction', REFID: 1, TAGID: 5 });
+
+            expect(mockGetFirstListItem).toHaveBeenCalledWith('REFTYPE = "Transaction" && REFID = 1 && TAGID = 5');
+            expect(result).toEqual(PB_MOCK_SUCCESS_RECORD);
+        });
     });
 
     describe('Subscriptions', () => {

--- a/tests/database/DatabaseService.test.js
+++ b/tests/database/DatabaseService.test.js
@@ -214,6 +214,42 @@ describe('DatabaseService', () => {
             expect(mockRun).toHaveBeenCalledWith(10);
             expect(mockExec).toHaveBeenCalledWith('COMMIT');
         });
+
+        test('resolveTagLinkConflict deletes old record and inserts new synchronized record', () => {
+            service.schemas = {
+                ...service.schemas,
+                'TAGLINK_V1': {
+                    pk: 'TAGLINKID',
+                    fields: ['REFTYPE', 'REFID', 'TAGID'],
+                    techFields: ['pb_id', 'pb_is_dirty', 'pb_updated_at']
+                }
+            };
+
+            const remoteRecord = {
+                id: 'pb_taglink_123',
+                TAGLINKID: 123,
+                REFTYPE: 'Transaction',
+                REFID: 10,
+                TAGID: 5,
+                _updated_at: '2023-01-01T12:00:00Z'
+            };
+
+            mockRun.mockReturnValue({ lastInsertRowid: 50 });
+
+            service.resolveTagLinkConflict(45, remoteRecord);
+
+            expect(mockExec).toHaveBeenCalledWith('BEGIN TRANSACTION');
+            // Delete old record
+            expect(mockPrepare).toHaveBeenCalledWith('DELETE FROM TAGLINK_V1 WHERE ROWID = ?');
+            expect(mockRun).toHaveBeenCalledWith(45);
+
+            // Insert new record
+            expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO TAGLINK_V1'));
+            // Check mark synced
+            expect(mockPrepare).toHaveBeenCalledWith('UPDATE TAGLINK_V1 SET pb_is_dirty = 0 WHERE ROWID = ?');
+            expect(mockRun).toHaveBeenCalledWith(50);
+            expect(mockExec).toHaveBeenCalledWith('COMMIT');
+        });
     });
 
     describe('DB Management / init / schema', () => {

--- a/tests/services/SyncService.test.js
+++ b/tests/services/SyncService.test.js
@@ -31,6 +31,7 @@ describe('SyncService', () => {
             applyRemoteChanges: jest.fn(),
             getDeletedLog: jest.fn(),
             clearDeletedLog: jest.fn(),
+            resolveTagLinkConflict: jest.fn(),
             schemas: {
                 'ACCOUNTLIST_V1': { pk: 'ACCOUNTID' }
             }
@@ -40,6 +41,7 @@ describe('SyncService', () => {
             update: jest.fn(),
             create: jest.fn(),
             getByRowId: jest.fn(),
+            getRemoteRecordByUniqueKeys: jest.fn(),
             getFullList: jest.fn(),
             delete: jest.fn()
         };
@@ -128,6 +130,23 @@ describe('SyncService', () => {
             expect(mockPbService.getByRowId).toHaveBeenCalledWith('ACCOUNTLIST_V1', 1);
             expect(mockPbService.update).toHaveBeenCalledWith('ACCOUNTLIST_V1', 'pb_remote_123', expect.any(Object));
             expect(mockDbService.setSyncedStatus).toHaveBeenCalledWith('ACCOUNTLIST_V1', 1, 'pb_remote_123');
+        });
+
+        test('handles validation_not_unique error for TAGLINK_V1 by querying remote unique keys and resolving conflict', async () => {
+            const record = { rowid: 1, REFTYPE: 'Transaction', REFID: 10, TAGID: 5 };
+            mockDbService.getDirtyRecords.mockReturnValue([record]);
+
+            const validationError = { response: { data: { REFTYPE: { code: 'validation_not_unique' } } } };
+            mockPbService.create.mockRejectedValueOnce(validationError);
+
+            const remoteRecord = { id: 'pb_taglink_123', TAGLINKID: 123, REFTYPE: 'Transaction', REFID: 10, TAGID: 5 };
+            mockPbService.getRemoteRecordByUniqueKeys.mockResolvedValueOnce(remoteRecord);
+
+            await syncService.pushTable('TAGLINK_V1');
+
+            expect(mockPbService.create).toHaveBeenCalled();
+            expect(mockPbService.getRemoteRecordByUniqueKeys).toHaveBeenCalledWith('TAGLINK_V1', { REFTYPE: 'Transaction', REFID: 10, TAGID: 5 });
+            expect(mockDbService.resolveTagLinkConflict).toHaveBeenCalledWith(1, remoteRecord);
         });
     });
 


### PR DESCRIPTION
resolve issue when two client generate different taglink with same info (recurring transaction) but different key. Server win.